### PR TITLE
Improve comparison operator

### DIFF
--- a/lib/iron_mq/message.rb
+++ b/lib/iron_mq/message.rb
@@ -87,6 +87,7 @@ module IronMQ
     end
 
     def ==(other)
+      return false if other.class == NilClass
       id == other.id
     end
 

--- a/lib/iron_mq/message.rb
+++ b/lib/iron_mq/message.rb
@@ -87,7 +87,7 @@ module IronMQ
     end
 
     def ==(other)
-      return false if other.class == NilClass
+      return false unless other.respond_to? :id
       id == other.id
     end
 

--- a/lib/iron_mq/queue.rb
+++ b/lib/iron_mq/queue.rb
@@ -289,7 +289,7 @@ module IronMQ
     alias poll poll_messages
 
     def ==(other)
-      return false unless other.respond_to?(:id) && other.respond_to?(:project_id)
+      return false unless other.respond_to?(:name) && other.respond_to?(:project_id)
       name == other.name && project_id == other.project_id
     end
 

--- a/lib/iron_mq/queue.rb
+++ b/lib/iron_mq/queue.rb
@@ -289,6 +289,7 @@ module IronMQ
     alias poll poll_messages
 
     def ==(other)
+      return false if other.class == NilClass
       name == other.name && project_id == other.project_id
     end
 

--- a/lib/iron_mq/queue.rb
+++ b/lib/iron_mq/queue.rb
@@ -289,7 +289,7 @@ module IronMQ
     alias poll poll_messages
 
     def ==(other)
-      return false if other.class == NilClass
+      return false unless other.respond_to?(:id) && other.respond_to?(:project_id)
       name == other.name && project_id == other.project_id
     end
 

--- a/test/iron_mq/test_message.rb
+++ b/test/iron_mq/test_message.rb
@@ -41,6 +41,17 @@ class TestMessage < Minitest::Test
     end
   end
 
+  def test_compare_messages
+    message = IronMQ::Message.new(@client, @qname, id: '6161270473550831393')
+    same_message = IronMQ::Message.new(@client, @qname, id: '6161270473550831393')
+    not_same_message = IronMQ::Message.new(@client, @qname, id: '6161270473550831394')
+    nil_message = nil
+
+    assert message == same_message
+    assert message != not_same_message
+    assert message != nil_message
+  end
+
   def test_touch
     bodies = make_messages_bodies(2)
     resp = @queue.post_messages(bodies)

--- a/test/iron_mq/test_queue.rb
+++ b/test/iron_mq/test_queue.rb
@@ -27,6 +27,16 @@ class TestQueue < Minitest::Test
     BASIC_FIELDS.each { |f| refute_nil queue.public_send(f) }
   end
 
+  def test_compare_queues
+    same_queue = @client.queue(@qname + '')
+    not_same_queue = @client.queue(@qname + '_suffix')
+    nil_queue = nil
+
+    assert @queue == same_queue
+    assert @queue != not_same_queue
+    assert @queue != nil_queue
+  end
+
   def test_create_queue
     @queue.create!
     assert_basic_fields_exist @queue


### PR DESCRIPTION
Features

* prevent `undefined method name for nil:NilClass` in case of `queue == nil` comparison
* prevent `undefined method id for nil:NilClass` in case of `message == nil` comparison